### PR TITLE
fix : fix helm label/key name to RFC1123

### DIFF
--- a/deploy/helm/creeper-keeper/templates/configmap/discord-bot.yaml
+++ b/deploy/helm/creeper-keeper/templates/configmap/discord-bot.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 metadata:
   name: discord-bot-config
 data:
-  BOT_TOKEN: {{ .Values.token.bot }}
-  MINECRAFT_API_PATH: {{ .Values.urls.minecraft-api }}
+  BOT_TOKEN: "{{ .Values.token.bot }}"
+  MINECRAFT_API_PATH: "{{ .Values.urls.minecraft }}"

--- a/deploy/helm/creeper-keeper/values.yaml
+++ b/deploy/helm/creeper-keeper/values.yaml
@@ -7,4 +7,4 @@ token:
   bot: <discord-bot-token>
 
 urls:
-  minecraft-api: <minecraft-api-url:port>
+  minecraft: <minecraft-api-url:port>


### PR DESCRIPTION
### Fix helm chart label name
- remove dash ("-") in label name
  - get error like 
    ![image](https://github.com/user-attachments/assets/26d06e62-746f-4269-9611-3959e0c0a603)
- make the label characters to comply RFC1123
