### PR TITLE
Make gitlab ci/cd pipeline build docker image of this project and push to gitlab container registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,52 @@
 stages:
+  - prepare
+  - build
   - deploy
 
-before_script:
-  - git clone --depth 1 https://github.com/birdmandayum0131/CreeperKeeper.git
-  - cd CreeperKeeper
+variables:
+  GIT_STRATEGY: none
+
+prepare:
+  stage: prepare
+  image: alpine:latest
+  script:
+    - apk add --no-cache git
+    - git clone --depth 1 https://github.com/birdmandayum0131/CreeperKeeper.git
+    - cd CreeperKeeper
+    - echo "GITHUB_SHA=$(git rev-parse HEAD)" >> github.env
+  artifacts:
+    paths:
+      - CreeperKeeper/
+    reports:
+      dotenv: CreeperKeeper/github.env
+
+build:
+  stage: build
+  image: docker:24.0.5
+  services:
+    - docker:24.0.5-dind
+  variables:
+    DOCKER_TLS_CERTDIR: "/certs"
+    DOCKER_HOST: tcp://docker:2376
+    DOCKER_TLS_VERIFY: 1
+    DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
+  before_script:
+    - docker info
+  script:
+    - cd CreeperKeeper
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker build -t $CI_REGISTRY_IMAGE:$GITHUB_SHA .
+    - docker push $CI_REGISTRY_IMAGE:$GITHUB_SHA
 
 deploy_to_k8s:
   stage: deploy
   image: dtzar/helm-kubectl:latest
   script:
+    - cd CreeperKeeper
     - kubectl config get-contexts
     - kubectl config use-context birdman0131/kubernetes-agent:k3s-home-agent
-    - helm upgrade --install creeper-keeper deploy/helm/creeper-keeper -n discord-bot --set token.bot="$DISCORD_BOT_TOKEN" --set urls.minecraft="$MINECRAFT_API_URL"
+    - helm upgrade --install creeper-keeper deploy/helm/creeper-keeper -n discord-bot
+      --set token.bot="$DISCORD_BOT_TOKEN"
+      --set urls.minecraft="$MINECRAFT_API_URL"
+      --set image.repository="$CI_REGISTRY_IMAGE"
+      --set image.tag="$GITHUB_SHA"

--- a/deploy/helm/creeper-keeper/templates/deployment/discord-bot.yaml
+++ b/deploy/helm/creeper-keeper/templates/deployment/discord-bot.yaml
@@ -12,8 +12,8 @@ spec:
     spec:
       containers:
         - name: discord-bot-container
-          image: "creeper-keeper:latest"
-          imagePullPolicy: Never
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: discord-bot-config

--- a/deploy/helm/creeper-keeper/templates/deployment/discord-bot.yaml
+++ b/deploy/helm/creeper-keeper/templates/deployment/discord-bot.yaml
@@ -10,6 +10,8 @@ spec:
     metadata:
       labels: {{.Values.podSelector.bot | toYaml | nindent 8}}
     spec:
+      imagePullSecrets:
+        - name: gitlab-registry-secret
       containers:
         - name: discord-bot-container
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/helm/creeper-keeper/values.yaml
+++ b/deploy/helm/creeper-keeper/values.yaml
@@ -8,3 +8,7 @@ token:
 
 urls:
   minecraft: <minecraft-api-url:port>
+
+image:
+  repository: creeper-keeper
+  tag: latest


### PR DESCRIPTION
### add prepare stage to clone project
  - gitlab project not mirror from github project ( gitlab premium feature )
  - clone project each ci/cd flow so gitlab project can be empty
  - use artifact to keep project folder and env
  - use github commit sha as built image tag
### add build stage to build docker image
  - use dind (docker in docker) service -> need setup gitlab first
  - push image to gitlab container registry
    - use github latest commit sha as image tag
### pull image in deploy stage
  - use secret to pull image from gitlab container registry
