### PR TITLE
Fix refresh button disabled after first time get pressed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiosignal==1.3.1
 async-timeout==4.0.3
 attrs==23.1.0
 charset-normalizer==3.2.0
-discord.py==2.3.2
+discord.py==2.4.0
 frozenlist==1.4.0
 idna==3.4
 multidict==6.0.4

--- a/view.py
+++ b/view.py
@@ -29,7 +29,7 @@ class ServerManageView(discord.ui.View):
             async with session.post(os.getenv("MINECRAFT_API_PATH") + "/api/v1/server/minecraft/start") as resp:
                 if resp.status != 200:
                     err = await resp.text()
-                    interaction.response.send_message("Error: " + err)
+                    await interaction.response.send_message("Error: " + err)
                     return
 
         self.startButton.disabled = True
@@ -43,7 +43,7 @@ class ServerManageView(discord.ui.View):
             async with session.post(os.getenv("MINECRAFT_API_PATH") + "/api/v1/server/minecraft/stop") as resp:
                 if resp.status != 200:
                     err = await resp.text()
-                    interaction.response.send_message("Error: " + err)
+                    await interaction.response.send_message("Error: " + err)
                     return
 
         self.stopButton.disabled = True
@@ -59,7 +59,7 @@ class ServerManageView(discord.ui.View):
             async with session.get(os.getenv("MINECRAFT_API_PATH") + "/api/v1/server/minecraft/status") as resp:
                 if resp.status != 200:
                     err = await resp.text()
-                    interaction.response.send_message("Error: " + err)
+                    await interaction.response.send_message("Error: " + err)
                     return
 
                 data = await resp.json()

--- a/view.py
+++ b/view.py
@@ -53,8 +53,6 @@ class ServerManageView(discord.ui.View):
         await interaction.message.edit(content=minecraft_server_message.format(serverStatus="offline"), view=self)
 
     async def updateServerCallback(self, interaction: discord.Interaction):
-        self.updateButton.disabled = True
-        await interaction.response.edit_message(view=self)
         async with aiohttp.ClientSession() as session:
             async with session.get(os.getenv("MINECRAFT_API_PATH") + "/api/v1/server/minecraft/status") as resp:
                 if resp.status != 200:
@@ -67,4 +65,4 @@ class ServerManageView(discord.ui.View):
         self.serverOnline = server_status == "online"
         self.startButton.disabled = self.serverOnline
         self.stopButton.disabled = not self.serverOnline
-        await interaction.message.edit(content=minecraft_server_message.format(serverStatus=server_status), view=self)
+        await interaction.response.edit_message(content=minecraft_server_message.format(serverStatus=server_status), view=self)


### PR DESCRIPTION
### update requirement.txt
- new persistent button / message feature need the latest version of discord.py
### fix error handling function not be awaited
- error reporting function not be awaited so it won't response any message
### fix refresh button disabled after first time get pressed
- some deprecated code not be removed completely cause this bug
  ![image](https://github.com/user-attachments/assets/87c14dfd-499a-425e-9aec-702e67330156)
