### PR TITLE
Refactor code structure, show error message on discord view

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from view import ServerManageView
+from view import ServerControlView
 
 
 class MinecraftServerBot(commands.Bot):
@@ -11,7 +11,7 @@ class MinecraftServerBot(commands.Bot):
         super().__init__(command_prefix=commands.when_mentioned_or('!'), intents=intents)
 
     async def setup_hook(self) -> None:
-        self.add_view(ServerManageView())
+        self.add_view(ServerControlView())
 
     async def on_ready(self):
         print(f'Logged in as {self.user} (ID: {self.user.id})')

--- a/button.py
+++ b/button.py
@@ -21,10 +21,10 @@ class StopServerButton(discord.ui.Button):
         )
 
 
-class UpdateServerButton(discord.ui.Button):
+class RefreshServerButton(discord.ui.Button):
     def __init__(self):
         super().__init__(
             label="Refresh Server Status",
             style=discord.ButtonStyle.blurple,
-            custom_id="update_server_button",
+            custom_id="refresh_status_button",
         )

--- a/commands.py
+++ b/commands.py
@@ -1,7 +1,7 @@
 # * Commands
 import os
 import aiohttp
-from view import ServerManageView
+from view import ServerControlView
 from data.message import minecraft_server_message
 from discord.ext.commands import Context
 from bot import bot
@@ -23,5 +23,5 @@ async def minecraft(ctx: Context):
 
             data = await resp.json()
             minecraft_server_status = data.get("serverStatus")
-            view = ServerManageView(minecraft_server_status)
+            view = ServerControlView(minecraft_server_status)
             await ctx.send(content=minecraft_server_message.format(serverStatus=minecraft_server_status), view=view)

--- a/commands.py
+++ b/commands.py
@@ -1,8 +1,5 @@
 # * Commands
-import os
-import aiohttp
 from view import ServerControlView
-from data.message import minecraft_server_message
 from discord.ext.commands import Context
 from bot import bot
 
@@ -14,14 +11,6 @@ async def ping(ctx: Context):
 
 @bot.command()
 async def minecraft(ctx: Context):
-    async with aiohttp.ClientSession() as session:
-        async with session.get(os.getenv("MINECRAFT_API_PATH") + "/api/v1/server/minecraft/status") as resp:
-            if resp.status != 200:
-                err = await resp.text()
-                await ctx.send("Fetch server status failed:" + err)
-                return
-
-            data = await resp.json()
-            minecraft_server_status = data.get("serverStatus")
-            view = ServerControlView(minecraft_server_status)
-            await ctx.send(content=minecraft_server_message.format(serverStatus=minecraft_server_status), view=view)
+    view = ServerControlView()
+    await view.RefreshServerStatus()
+    await ctx.send(content=view.ServerControlMessage, view=view)

--- a/data/message.py
+++ b/data/message.py
@@ -16,6 +16,13 @@ def value(message: str) -> str:
     return f"{colors.colorize(message, fg='blue', bold=True)}"
 
 
+def Error(message: str) -> str:
+    return f"""```ansi
+{colors.colorize(message, fg='red', bg='white', bold=True)}
+```
+"""
+
+
 minecraft_server_message = f"""
 **【Minecraft 伺服器】**
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -43,4 +50,5 @@ __ *( 伺服器啟動大約需要 30 秒到 1 分鐘 )* __
 {field('伺服器版本 : ')}{value('1.21.1')}
 {field('伺服器狀態 : ')}{value('{serverStatus}')}
 ```
+{{errorMessage}}
 """

--- a/data/message.py
+++ b/data/message.py
@@ -1,4 +1,22 @@
-minecraft_server_message = """
+import discord_colorize
+
+colors = discord_colorize.Colors()
+
+
+# * Define common used colors
+def title(message: str) -> str:
+    return f"{colors.colorize(message, fg='pink', bold=True)}"
+
+
+def field(message: str) -> str:
+    return f"{colors.colorize(message, fg='green', bold=True)}"
+
+
+def value(message: str) -> str:
+    return f"{colors.colorize(message, fg='blue', bold=True)}"
+
+
+minecraft_server_message = f"""
 **【Minecraft 伺服器】**
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  如果你不知道該怎麼連線:point_down:
@@ -20,10 +38,9 @@ minecraft_server_message = """
 
 __ *( 伺服器啟動大約需要 30 秒到 1 分鐘 )* __
 ```ansi
-[2;35m[伺服器資訊]
-[2;34m[2;36m[2;37m[2;35m[2;37m[2;32m[2;34m[2;32m伺服器位址 : [0m[2;34m[0m[2;32m[0m[2;37m[0m[2;35m[0m[2;37m[0m[2;36m[2;37m[2;31m[2;30m[2;34m[2;32m[2;34mminecraft.bardbird.com[0m[2;32m
-[2;33m[2;37m[2;34m[2;32m伺服器版本 : [0m[2;34m[0m[2;37m[0m[2;33m[2;32m[2;34m1.21.1
-[2;37m[2;34m[2;32m伺服器狀態 : [0m[2;34m[0m[2;37m[0m[2;34m[2;32m[2;34m{serverStatus}[0m[2;32m[0m[2;34m
-[0m[2;32m[0m[2;33m[0m[2;32m[0m[2;34m[0m[2;30m[0m[2;31m[0m[2;37m[0m[2;36m[0m[2;34m[0m[2;35m[0m
+{title('[伺服器資訊]')}
+{field('伺服器位址 : ')}{value('minecraft.bardbird.com')}
+{field('伺服器版本 : ')}{value('1.21.1')}
+{field('伺服器狀態 : ')}{value('{serverStatus}')}
 ```
 """

--- a/main.py
+++ b/main.py
@@ -3,9 +3,10 @@ import commands  # * setup commands
 from dotenv import load_dotenv
 from bot import bot
 
-# * Load environment variable
-load_dotenv()
-token = os.getenv("BOT_TOKEN")
+if __name__ == "__main__":
+    # * Load environment variable
+    load_dotenv()
+    token = os.getenv("BOT_TOKEN")
 
-# * run bot
-bot.run(token=token)
+    # * run bot
+    bot.run(token=token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
-aiohttp==3.8.5
+﻿aiohttp==3.8.5
 aiosignal==1.3.1
 async-timeout==4.0.3
+asyncio==3.4.3
 attrs==23.1.0
 charset-normalizer==3.2.0
 discord.py==2.4.0
+discord_colorize==0.0.8
 frozenlist==1.4.0
 idna==3.4
 multidict==6.0.4

--- a/view.py
+++ b/view.py
@@ -80,3 +80,7 @@ class ServerControlView(discord.ui.View):
         self.startButton.disabled = self.serverOnline
         self.stopButton.disabled = not self.serverOnline
         await interaction.response.edit_message(content=minecraft_server_message.format(serverStatus=server_status), view=self)
+
+    @classmethod
+    def ServerControlMessage(cls, server_status: str) -> str:
+        return minecraft_server_message.format(serverStatus=server_status)

--- a/view.py
+++ b/view.py
@@ -6,7 +6,21 @@ import asyncio
 from data.message import minecraft_server_message
 
 
-class ServerManageView(discord.ui.View):
+class ServerControlView(discord.ui.View):
+    """
+    A view class for managing the minecraft server, with buttons of start, stop, and refresh.
+
+    Start Button: send a POST request to minecraft api to start the server
+    Stop Button: send a POST request to minecraft api to stop the server
+    Refresh Button: send a GET request to minecraft api to fetch the server status
+
+    Attributes:
+        serverOnline (str): The status of the server, either "online" or "offline".
+        startButton (discord.ui.Button): The button for starting the server.
+        stopButton (discord.ui.Button): The button for stopping the server.
+        updateButton (discord.ui.Button): The button for fetching the server status.
+    """
+
     def __init__(self, server_status: str = "offline"):
         super().__init__(timeout=None)
         self.api_root = os.getenv("MINECRAFT_API_PATH")


### PR DESCRIPTION
### Add discord_colorize package
> Discord can show colorzie message with markdown code block, but code block with most language is not easy to customize text with specific color

Luckly, discord markdown also support ansi language which have Escape Codes to colorize any segment of code.
> reference : https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797

In a nutshell, escape code is hard to debug if it show raw in file, so we import this package to manage that
> reference : https://pypi.org/project/discord-colorize/
### Refactor code structure of ServerConrolView
- rename some classname, custom_id, field_name to more accessible name.
- refactor all api call to instance method

### Show error message in server control message
Not showed on responsed extra message anymore cuz this way is more easy to use.
<img src="https://github.com/user-attachments/assets/43295495-f1e9-47b1-a7ce-9cf7eef44264" width="500"/>
